### PR TITLE
fix(terminal): Fix blank terminal issue and improve error handling

### DIFF
--- a/app/backend/server.js
+++ b/app/backend/server.js
@@ -326,7 +326,7 @@ terminalWss.on('connection', async (ws, req) => {
     try {
         const container = docker.getContainer(containerId);
         const exec = await container.exec({
-            Cmd: ['/bin/sh', '-c', 'TERM=xterm-256color; export TERM; /bin/sh'],
+            Cmd: ['/bin/sh'],
             AttachStdin: true,
             AttachStdout: true,
             AttachStderr: true,

--- a/app/frontend/src/components/TerminalDialog.js
+++ b/app/frontend/src/components/TerminalDialog.js
@@ -37,6 +37,14 @@ const TerminalDialog = ({ open, onClose, containerId, containerName }) => {
       const wsUrl = `${wsProtocol}://${wsHost}/ws/terminal/${containerId}`;
 
       const socket = new WebSocket(wsUrl);
+
+      socket.onclose = () => {
+          if (xterm.current) {
+              xterm.current.writeln('');
+              xterm.current.writeln('--- CONNECTION CLOSED ---');
+          }
+      };
+
       const attachAddon = new AttachAddon(socket);
       xterm.current.loadAddon(attachAddon);
 


### PR DESCRIPTION
This commit addresses a bug where the interactive terminal would appear blank for some container images.

The fix involves:
- Simplifying the `exec` command on the backend from a complex `TERM`-setting command to a more robust and widely compatible `['/bin/sh']`. This is the primary fix for the blank terminal issue.
- Enhancing the frontend `TerminalDialog` component to display a "CONNECTION CLOSED" message if the WebSocket disconnects unexpectedly, providing better feedback to you.