### PR TITLE
feat: Add container deployment feature

### DIFF
--- a/app/backend/server.js
+++ b/app/backend/server.js
@@ -44,6 +44,25 @@ app.get('/api/system', async (req, res) => {
     }
 });
 
+// Create and start a new container
+app.post('/api/containers/create', async (req, res) => {
+    try {
+        const container = await docker.createContainer(req.body);
+        await container.start();
+        res.status(201).json({ message: 'Container created and started successfully', id: container.id });
+    } catch (error) {
+        console.error('Error creating container:', error);
+        if (error.statusCode === 404) {
+            res.status(404).json({ message: `Image not found: ${req.body.Image}` });
+        } else if (error.statusCode === 409) {
+            res.status(409).json({ message: `Container name "${req.body.name}" is already in use.` });
+        }
+        else {
+            res.status(500).json({ message: 'Error creating container', error: error.message });
+        }
+    }
+});
+
 // Get all images
 app.get('/api/images', async (req, res) => {
     try {

--- a/app/frontend/src/components/ContainerList.js
+++ b/app/frontend/src/components/ContainerList.js
@@ -3,12 +3,13 @@ import {
   Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper,
   Button, ButtonGroup, Chip, Typography, Box, IconButton, Tooltip, TextField
 } from '@mui/material';
-import { PlayArrow, Stop, RestartAlt, Refresh, Pause, Delete, Search, Description, Terminal } from '@mui/icons-material';
+import { PlayArrow, Stop, RestartAlt, Refresh, Pause, Delete, Search, Description, Terminal, Add } from '@mui/icons-material';
 import * as api from '../services/api';
 import ContainerInspectDialog from './ContainerInspectDialog';
 import LogViewerDialog from './LogViewerDialog';
 import ConfirmationDialog from './ConfirmationDialog';
 import TerminalDialog from './TerminalDialog';
+import CreateContainerDialog from './CreateContainerDialog';
 
 // --- Helper Functions ---
 const formatMemory = (bytes) => {
@@ -40,6 +41,7 @@ const ContainerList = () => {
   const [logsDialogOpen, setLogsDialogOpen] = useState(false);
   const [terminalDialogOpen, setTerminalDialogOpen] = useState(false);
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [selectedContainer, setSelectedContainer] = useState(null);
   const [confirmAction, setConfirmAction] = useState(null);
   const ws = useRef(null);
@@ -196,8 +198,12 @@ const ContainerList = () => {
           <Button variant="contained" onClick={fetchContainers} disabled={loading} startIcon={<Refresh />} sx={{ borderRadius: '8px', textTransform: 'none', background: 'var(--primary)', '&:hover': { background: 'var(--primary-dark)' } }}>
             Refresh
           </Button>
+          <Button variant="contained" onClick={() => setCreateDialogOpen(true)} startIcon={<Add />} sx={{ borderRadius: '8px', textTransform: 'none', background: 'var(--success)', '&:hover': { background: '#059669' } }}>
+            New Container
+          </Button>
         </Box>
       </Box>
+      <CreateContainerDialog open={createDialogOpen} onClose={() => setCreateDialogOpen(false)} onCreated={fetchContainers} />
       <TableContainer>
         <Table sx={{
             width: '100%',

--- a/app/frontend/src/components/CreateContainerDialog.js
+++ b/app/frontend/src/components/CreateContainerDialog.js
@@ -1,0 +1,145 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField,
+  Box, IconButton, Autocomplete, Chip
+} from '@mui/material';
+import { AddCircleOutline, RemoveCircleOutline } from '@mui/icons-material';
+import * as api from '../services/api';
+
+const CreateContainerDialog = ({ open, onClose, onCreated }) => {
+  const [image, setImage] = useState('');
+  const [name, setName] = useState('');
+  const [ports, setPorts] = useState([{ host: '', container: '' }]);
+  const [envs, setEnvs] = useState([{ key: '', value: '' }]);
+  const [volumes, setVolumes] = useState([{ host: '', container: '' }]);
+
+  const [availableImages, setAvailableImages] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      const fetchImages = async () => {
+        try {
+          const response = await api.getImages();
+          const imageNames = response.data.flatMap(img => img.RepoTags || []);
+          setAvailableImages(imageNames);
+        } catch (err) {
+          console.error("Failed to fetch images", err);
+        }
+      };
+      fetchImages();
+    }
+  }, [open]);
+
+  const handleAddField = (setter, field) => setter(prev => [...prev, field]);
+  const handleRemoveField = (setter, index) => setter(prev => prev.filter((_, i) => i !== index));
+  const handleFieldChange = (setter, index, event) => {
+    const { name, value } = event.target;
+    setter(prev => {
+      const newFields = [...prev];
+      newFields[index][name] = value;
+      return newFields;
+    });
+  };
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    setError('');
+
+    const formatPorts = () => {
+        const portBindings = {};
+        ports.forEach(p => {
+            if (p.container && p.host) {
+                portBindings[`${p.container}/tcp`] = [{ HostPort: p.host }];
+            }
+        });
+        return portBindings;
+    };
+
+    const config = {
+      Image: image,
+      name: name,
+      Env: envs.filter(e => e.key).map(e => `${e.key}=${e.value}`),
+      HostConfig: {
+        PortBindings: formatPorts(),
+        Binds: volumes.filter(v => v.host && v.container).map(v => `${v.host}:${v.container}`),
+      },
+    };
+
+    try {
+      await api.createContainer(config);
+      onCreated(); // Callback to refresh container list
+      onClose(); // Close dialog on success
+    } catch (err) {
+      console.error("Error creating container", err);
+      setError(err.response?.data?.message || 'Failed to create container.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>Create New Container</DialogTitle>
+      <DialogContent>
+        <Autocomplete
+          freeSolo
+          options={availableImages}
+          value={image}
+          onChange={(event, newValue) => setImage(newValue)}
+          renderInput={(params) => (
+            <TextField {...params} label="Image" margin="normal" required />
+          )}
+        />
+        <TextField label="Container Name" value={name} onChange={e => setName(e.target.value)} fullWidth margin="normal" />
+
+        <Box mt={2}>
+          <Typography>Port Mappings</Typography>
+          {ports.map((p, i) => (
+            <Box key={i} display="flex" gap={1} alignItems="center" mt={1}>
+              <TextField label="Host Port" name="host" value={p.host} onChange={e => handleFieldChange(setPorts, i, e)} />
+              <TextField label="Container Port" name="container" value={p.container} onChange={e => handleFieldChange(setPorts, i, e)} />
+              <IconButton onClick={() => handleRemoveField(setPorts, i)}><RemoveCircleOutline /></IconButton>
+            </Box>
+          ))}
+          <Button startIcon={<AddCircleOutline />} onClick={() => handleAddField(setPorts, { host: '', container: '' })}>Add Port</Button>
+        </Box>
+
+        <Box mt={2}>
+          <Typography>Environment Variables</Typography>
+          {envs.map((e, i) => (
+            <Box key={i} display="flex" gap={1} alignItems="center" mt={1}>
+              <TextField label="Key" name="key" value={e.key} onChange={e => handleFieldChange(setEnvs, i, e)} />
+              <TextField label="Value" name="value" value={e.value} onChange={e => handleFieldChange(setEnvs, i, e)} />
+              <IconButton onClick={() => handleRemoveField(setEnvs, i)}><RemoveCircleOutline /></IconButton>
+            </Box>
+          ))}
+          <Button startIcon={<AddCircleOutline />} onClick={() => handleAddField(setEnvs, { key: '', value: '' })}>Add Variable</Button>
+        </Box>
+
+        <Box mt={2}>
+          <Typography>Volume Mounts</Typography>
+          {volumes.map((v, i) => (
+            <Box key={i} display="flex" gap={1} alignItems="center" mt={1}>
+              <TextField label="Host Path" name="host" value={v.host} onChange={e => handleFieldChange(setVolumes, i, e)} />
+              <TextField label="Container Path" name="container" value={v.container} onChange={e => handleFieldChange(setVolumes, i, e)} />
+              <IconButton onClick={() => handleRemoveField(setVolumes, i)}><RemoveCircleOutline /></IconButton>
+            </Box>
+          ))}
+          <Button startIcon={<AddCircleOutline />} onClick={() => handleAddField(setVolumes, { host: '', container: '' })}>Add Volume</Button>
+        </Box>
+
+        {error && <Typography color="error" sx={{ mt: 2 }}>{error}</Typography>}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleSubmit} variant="contained" disabled={loading}>
+          {loading ? 'Creating...' : 'Create and Start'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default CreateContainerDialog;

--- a/app/frontend/src/services/api.js
+++ b/app/frontend/src/services/api.js
@@ -51,3 +51,7 @@ export const getImages = () => {
 export const removeImage = (id, force = false) => {
     return apiClient.delete(`/images/${id}?force=${force}`);
 };
+
+export const createContainer = (config) => {
+    return apiClient.post('/containers/create', config);
+};


### PR DESCRIPTION
I've introduced a new feature to let you deploy Docker containers directly from the dashboard UI.

This feature includes:
- A new backend API endpoint (`/api/containers/create`) to handle the creation and starting of new containers from a given configuration.
- A new "New Container" button in the UI that opens a comprehensive dialog form.
- The form allows you to specify the image, container name, port mappings, environment variables, and volume mounts.
- The image field includes an autocomplete feature populated with locally available images.