### PR TITLE
fix(frontend): Add missing import to fix build error

### DIFF
--- a/app/frontend/src/components/CreateContainerDialog.js
+++ b/app/frontend/src/components/CreateContainerDialog.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import {
   Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField,
-  Box, IconButton, Autocomplete, Chip
+  Box, IconButton, Autocomplete, Chip, Typography
 } from '@mui/material';
 import { AddCircleOutline, RemoveCircleOutline } from '@mui/icons-material';
 import * as api from '../services/api';


### PR DESCRIPTION
This commit fixes a build failure in the frontend application. The `CreateContainerDialog.js` component was using the `Typography` component from Material-UI without importing it, which caused the `npm run build` command to fail with a `react/jsx-no-undef` error.

This change adds the missing import, allowing the frontend to build successfully.