### PR TITLE
fix(frontend): Add Nginx config for SPA routing

### DIFF
--- a/app/frontend/Dockerfile
+++ b/app/frontend/Dockerfile
@@ -19,6 +19,9 @@ FROM nginx:1.21-alpine
 # Copy the built files from the build stage
 COPY --from=build /app/build /usr/share/nginx/html
 
+# Copy the custom nginx configuration
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
 # Expose port 80
 EXPOSE 80
 

--- a/app/frontend/nginx.conf
+++ b/app/frontend/nginx.conf
@@ -1,0 +1,22 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Optional: Add a location block for the API to be proxied
+    # This is not strictly necessary if the frontend is calling the backend directly
+    # or if another reverse proxy is in front of this one, but it's good practice.
+    location /api {
+        # This would be proxied to the backend service
+        # In a real production setup, you would replace this with the backend's address
+        # For example: proxy_pass http://backend:3001;
+        # For now, we'll just return a 404 as this Nginx config is for the frontend only.
+        return 404;
+    }
+}


### PR DESCRIPTION
This commit fixes a bug where refreshing the page on any client-side route (e.g., /images) would result in a 404 Not Found error from the Nginx server.

The fix involves:
- Creating a custom `nginx.conf` file with a `try_files` directive. This directive ensures that any request that doesn't match a static file will fall back to serving `index.html`, allowing the React router to handle the route.
- Updating the frontend `Dockerfile` to copy this custom configuration into the production image, replacing the default Nginx config.