### PR TITLE
fix(auth): Seed default admin user on first startup

### DIFF
--- a/.env
+++ b/.env
@@ -10,6 +10,10 @@ MONGO_ROOT_PASSWORD=secretpassword
 MONGO_DB=docker_manager
 MONGODB_URI=mongodb://dockeradmin:secretpassword@mongodb:27017/docker_manager?authSource=admin
 
+# Default Admin User
+DEFAULT_ADMIN_USER=dockeradmin
+DEFAULT_ADMIN_PASSWORD=admin123
+
 # Security (JWT)
 JWT_SECRET=a-very-secret-jwt-key-for-dev
 JWT_REFRESH_SECRET=another-very-secret-jwt-key-for-dev

--- a/app/backend/server.js
+++ b/app/backend/server.js
@@ -16,9 +16,30 @@ const docker = new Docker({ socketPath: '/var/run/docker.sock' });
 const mongoose = require('mongoose');
 require('dotenv').config();
 
+const User = require('./models/User');
+
 // Connect to MongoDB
 mongoose.connect(process.env.MONGODB_URI)
-    .then(() => console.log('MongoDB connected...'))
+    .then(() => {
+        console.log('MongoDB connected...');
+        // Seed initial admin user if no users exist
+        const seedAdminUser = async () => {
+            try {
+                const userCount = await User.countDocuments();
+                if (userCount === 0) {
+                    console.log('No users found, creating default admin user...');
+                    await User.create({
+                        username: process.env.DEFAULT_ADMIN_USER,
+                        password: process.env.DEFAULT_ADMIN_PASSWORD,
+                    });
+                    console.log('Default admin user created.');
+                }
+            } catch (error) {
+                console.error('Error seeding admin user:', error);
+            }
+        };
+        seedAdminUser();
+    })
     .catch(err => console.error('MongoDB connection error:', err));
 
 


### PR DESCRIPTION
This commit fixes a critical issue where it was impossible for any user to log in because there was no way to create the first user.

The fix involves:
- Adding logic to the backend server to check if any users exist in the database upon startup.
- If the user collection is empty, a default administrator user is created using credentials from the .env file (`DEFAULT_ADMIN_USER` and `DEFAULT_ADMIN_PASSWORD`).
- Adding the default admin credentials to the `.env` file.

This ensures that on the first run of the application, a default user is available to log in with.