### PR TITLE
fix(frontend): Install wget in production image for healthcheck

### DIFF
--- a/app/frontend/Dockerfile
+++ b/app/frontend/Dockerfile
@@ -16,6 +16,9 @@ RUN npm run build
 # Stage 2: Serve the application with Nginx
 FROM nginx:1.21-alpine
 
+# Install wget for health checks
+RUN apk add --no-cache wget
+
 # Copy the built files from the build stage
 COPY --from=build /app/build /usr/share/nginx/html
 


### PR DESCRIPTION
This commit fixes an issue where the frontend container would be reported as "unhealthy" in a production environment.

The health check defined in the production `docker-compose.yml` (from the `vps-setup.sh` script) uses `wget` to check if the Nginx server is responding. However, the minimal `nginx:alpine` base image does not include `wget` by default.

This change adds a `RUN apk add --no-cache wget` command to the frontend's Dockerfile to ensure the health check command can execute successfully.