### PR TITLE
fix(backend): Fix user seeding by loading env vars correctly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,14 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./app/backend:/app
       - /app/node_modules # This is to avoid the local node_modules overwriting the container's
-    env_file:
-      - ./.env
+    environment:
+      - NODE_ENV=${NODE_ENV}
+      - PORT=${PORT}
+      - MONGODB_URI=${MONGODB_URI}
+      - JWT_SECRET=${JWT_SECRET}
+      - JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET}
+      - DEFAULT_ADMIN_USER=${DEFAULT_ADMIN_USER}
+      - DEFAULT_ADMIN_PASSWORD=${DEFAULT_ADMIN_PASSWORD}
     networks:
       - docker_manager_network
     depends_on:


### PR DESCRIPTION
This commit fixes a bug where the default admin user was not being created on first startup due to environment variables being undefined.

The `env_file` directive in docker-compose.yml was not reliably passing the variables to the backend service in the user's environment. This was causing the `User.create` call to fail validation because the username and password were not present.

The fix replaces the `env_file` directive with a more explicit `environment` block in the `docker-compose.yml` file. This ensures that all necessary environment variables are loaded from the `.env` file and correctly injected into the backend container.