### PR TITLE
feat(auth): Add logout functionality

### DIFF
--- a/app/frontend/src/components/Header.js
+++ b/app/frontend/src/components/Header.js
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, Button, IconButton } from '@mui/material';
+import { Logout } from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
 
 const formatUptime = (seconds) => {
     if (!seconds) return '--';
@@ -12,6 +14,13 @@ const formatUptime = (seconds) => {
 };
 
 const Header = ({ staticInfo }) => {
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    localStorage.removeItem('dockerManagerToken');
+    navigate('/login');
+  };
+
   return (
     <Box sx={{
       background: 'rgba(255, 255, 255, 0.95)',
@@ -55,6 +64,9 @@ const Header = ({ staticInfo }) => {
           <Typography sx={{ fontSize: '12px', color: 'var(--text-light)', textTransform: 'uppercase' }}>Docker</Typography>
           <Typography sx={{ fontSize: '18px', fontWeight: 600, color: 'var(--dark)' }}>v{staticInfo?.dockerVersion || '...'}</Typography>
         </Box>
+        <IconButton onClick={handleLogout} sx={{ color: 'var(--text-light)' }} title="Logout">
+            <Logout />
+        </IconButton>
       </Box>
     </Box>
   );


### PR DESCRIPTION
This commit adds a logout button to the dashboard header.

When clicked, the button clears the user's authentication token from localStorage and redirects them to the login page. This provides a secure way for users to end their session.