### PR TITLE
fix(frontend): Correct build errors from refactoring

### DIFF
--- a/app/frontend/src/components/ImageList.js
+++ b/app/frontend/src/components/ImageList.js
@@ -39,7 +39,7 @@ const ImageList = () => {
   const handleRemoveImage = async (id) => {
     try {
       await api.removeImage(id);
-      fetchImages();
+      refresh();
     } catch (error) {
       console.error("Error removing image", error);
       // You might want to show a notification to the user here

--- a/app/frontend/src/pages/Dashboard.js
+++ b/app/frontend/src/pages/Dashboard.js
@@ -6,6 +6,7 @@ import ContainerStatsGrid from '../components/ContainerStatsGrid';
 import ContainerList from '../components/ContainerList';
 import ImageList from '../components/ImageList';
 import * as api from '../services/api';
+import { useDocker } from '../context/DockerContext';
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -25,8 +26,6 @@ function TabPanel(props) {
     </div>
   );
 }
-
-import { useDocker } from '../context/DockerContext';
 
 const Dashboard = () => {
   const { systemInfo } = useDocker();


### PR DESCRIPTION
This commit fixes two minor bugs that were introduced during the state management refactoring and were causing the production build to fail.

The fixes are:
1.  In `ImageList.js`, a call to a non-existent `fetchImages` function was replaced with the correct `refresh` function from the `DockerContext`.
2.  In `Dashboard.js`, a misplaced `import` statement was moved to the top of the file to comply with linter rules.