### PR TITLE
fix(frontend): Refactor data loading in DockerContext

### DIFF
--- a/app/frontend/src/components/ImageList.js
+++ b/app/frontend/src/components/ImageList.js
@@ -89,7 +89,7 @@ const ImageList = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {loading ? (
+            {loading.images ? (
               <TableRow>
                 <TableCell colSpan={5} align="center">
                     <Typography>Loading images...</Typography>


### PR DESCRIPTION
This commit fixes a bug where the UI would appear to be stuck in a loading state if any one of the initial API calls failed.

The `DockerContext` was previously fetching all initial data (containers, images, system info) with a single `Promise.all`. This meant that one failed request would prevent any data from being displayed.

The fix refactors the data fetching logic to be more granular. Each data type now has its own fetching function and loading state within the context. This makes the UI more resilient, as a failure to load one part of the data (e.g., images) will no longer prevent other parts (e.g., containers) from being displayed.