### PR TITLE
Feat: Configure default user role from .env file

### DIFF
--- a/.env
+++ b/.env
@@ -17,3 +17,4 @@ DEFAULT_ADMIN_PASSWORD=admin123
 # Security (JWT)
 JWT_SECRET=a-very-secret-jwt-key-for-dev
 JWT_REFRESH_SECRET=another-very-secret-jwt-key-for-dev
+USER_ROLE=Viewer

--- a/app/backend/models/User.js
+++ b/app/backend/models/User.js
@@ -15,7 +15,7 @@ const userSchema = new mongoose.Schema({
   role: {
     type: String,
     enum: ['Admin', 'Developer', 'Viewer'],
-    default: 'Viewer',
+    default: process.env.USER_ROLE || 'Viewer',
   },
   refreshTokens: [String],
 }, { timestamps: true });


### PR DESCRIPTION
This commit introduces the ability to configure the default role for newly registered users through an environment variable.

- Added `USER_ROLE` to the `.env` file to specify the default role.
- Updated the User model to use `process.env.USER_ROLE` as the default value for the `role` field, with a fallback to 'Viewer'.