### PR TITLE
feat: Add complete UI for network management

### DIFF
--- a/app/frontend/src/components/ConnectContainerDialog.js
+++ b/app/frontend/src/components/ConnectContainerDialog.js
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
+
+const ConnectContainerDialog = ({ open, onClose, onConnect, containers }) => {
+    const [selectedContainer, setSelectedContainer] = useState('');
+
+    const handleConnect = () => {
+        if (selectedContainer) {
+            onConnect(selectedContainer);
+        }
+        handleClose();
+    };
+
+    const handleClose = () => {
+        setSelectedContainer('');
+        onClose();
+    };
+
+    return (
+        <Dialog open={open} onClose={handleClose} fullWidth>
+            <DialogTitle>Connect a Container to the Network</DialogTitle>
+            <DialogContent>
+                <FormControl fullWidth sx={{ mt: 2 }}>
+                    <InputLabel id="container-select-label">Container</InputLabel>
+                    <Select
+                        labelId="container-select-label"
+                        id="container-select"
+                        value={selectedContainer}
+                        label="Container"
+                        onChange={(e) => setSelectedContainer(e.target.value)}
+                    >
+                        {containers.map((container) => (
+                            <MenuItem key={container.Id} value={container.Id}>
+                                {container.Names[0].substring(1)} ({container.Id.substring(0, 12)})
+                            </MenuItem>
+                        ))}
+                    </Select>
+                </FormControl>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleClose}>Cancel</Button>
+                <Button onClick={handleConnect} disabled={!selectedContainer}>Connect</Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default ConnectContainerDialog;

--- a/app/frontend/src/components/CreateNetworkDialog.js
+++ b/app/frontend/src/components/CreateNetworkDialog.js
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, TextField } from '@mui/material';
+import * as api from '../services/api';
+
+const CreateNetworkDialog = ({ open, onClose, onNetworkCreated }) => {
+    const [networkName, setNetworkName] = useState('');
+    const [driver, setDriver] = useState('bridge');
+
+    const handleCreate = async () => {
+        try {
+            await api.createNetwork({ Name: networkName, Driver: driver });
+            onNetworkCreated();
+        } catch (error) {
+            console.error("Error creating network", error);
+            // You might want to show an error to the user here
+        }
+        handleClose();
+    };
+
+    const handleClose = () => {
+        setNetworkName('');
+        setDriver('bridge');
+        onClose();
+    };
+
+    return (
+        <Dialog open={open} onClose={handleClose}>
+            <DialogTitle>Create a new Network</DialogTitle>
+            <DialogContent>
+                <DialogContentText>
+                    Please enter the details for the new network.
+                </DialogContentText>
+                <TextField
+                    autoFocus
+                    margin="dense"
+                    id="name"
+                    label="Network Name"
+                    type="text"
+                    fullWidth
+                    required
+                    variant="standard"
+                    value={networkName}
+                    onChange={(e) => setNetworkName(e.target.value)}
+                />
+                <TextField
+                    margin="dense"
+                    id="driver"
+                    label="Driver"
+                    type="text"
+                    fullWidth
+                    variant="standard"
+                    value={driver}
+                    onChange={(e) => setDriver(e.target.value)}
+                />
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleClose}>Cancel</Button>
+                <Button onClick={handleCreate} disabled={!networkName}>Create</Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default CreateNetworkDialog;

--- a/app/frontend/src/components/NetworkInspectDialog.js
+++ b/app/frontend/src/components/NetworkInspectDialog.js
@@ -1,0 +1,126 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+    Button, Dialog, DialogActions, DialogContent, DialogTitle, CircularProgress, Typography,
+    List, ListItem, ListItemText, IconButton, Divider, Box
+} from '@mui/material';
+import { Link as LinkIcon, LinkOff as LinkOffIcon } from '@mui/icons-material';
+import * as api from '../services/api';
+import { useDocker } from '../context/DockerContext';
+import ConnectContainerDialog from './ConnectContainerDialog';
+
+const NetworkInspectDialog = ({ open, onClose, networkId }) => {
+    const { containers } = useDocker();
+    const [networkDetails, setNetworkDetails] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [connectDialogOpen, setConnectDialogOpen] = useState(false);
+
+    const fetchNetworkDetails = useCallback(() => {
+        if (networkId) {
+            setLoading(true);
+            api.inspectNetwork(networkId)
+                .then(response => {
+                    setNetworkDetails(response.data);
+                })
+                .catch(error => {
+                    console.error("Error inspecting network", error);
+                })
+                .finally(() => {
+                    setLoading(false);
+                });
+        }
+    }, [networkId]);
+
+    useEffect(() => {
+        if (open) {
+            fetchNetworkDetails();
+        }
+    }, [open, fetchNetworkDetails]);
+
+    const handleDisconnect = async (containerId) => {
+        try {
+            await api.disconnectFromNetwork(networkId, containerId);
+            fetchNetworkDetails(); // Refresh details
+        } catch (error) {
+            console.error("Error disconnecting container", error);
+        }
+    };
+
+    const handleConnect = async (containerId) => {
+        try {
+            await api.connectToNetwork(networkId, containerId);
+            fetchNetworkDetails(); // Refresh details
+        } catch (error) {
+            console.error("Error connecting container", error);
+        }
+        setConnectDialogOpen(false);
+    };
+
+    const handleClose = () => {
+        setNetworkDetails(null);
+        onClose();
+    };
+
+    return (
+        <>
+            <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">
+                <DialogTitle>Inspect Network: {networkDetails?.Name}</DialogTitle>
+                <DialogContent>
+                    {loading ? (
+                        <CircularProgress />
+                    ) : networkDetails ? (
+                        <Box>
+                            <Typography variant="h6" gutterBottom>Details</Typography>
+                            <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all', maxHeight: '200px', overflowY: 'auto', backgroundColor: '#f5f5f5', padding: '10px', borderRadius: '4px' }}>
+                                {JSON.stringify({ ...networkDetails, Containers: undefined }, null, 2)}
+                            </pre>
+
+                            <Divider sx={{ my: 2 }} />
+
+                            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                                <Typography variant="h6" gutterBottom>Connected Containers</Typography>
+                                <Button
+                                    variant="outlined"
+                                    startIcon={<LinkIcon />}
+                                    onClick={() => setConnectDialogOpen(true)}
+                                >
+                                    Connect Container
+                                </Button>
+                            </Box>
+                            <List>
+                                {Object.keys(networkDetails.Containers).length > 0 ? (
+                                    Object.entries(networkDetails.Containers).map(([id, container]) => (
+                                        <ListItem
+                                            key={id}
+                                            secondaryAction={
+                                                <IconButton edge="end" aria-label="disconnect" onClick={() => handleDisconnect(id)}>
+                                                    <LinkOffIcon />
+                                                </IconButton>
+                                            }
+                                        >
+                                            <ListItemText primary={container.Name} secondary={id} />
+                                        </ListItem>
+                                    ))
+                                ) : (
+                                    <Typography sx={{ p: 2 }}>No containers connected.</Typography>
+                                )}
+                            </List>
+                        </Box>
+                    ) : (
+                        <Typography>Could not load network details.</Typography>
+                    )}
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleClose}>Close</Button>
+                </DialogActions>
+            </Dialog>
+            <ConnectContainerDialog
+                open={connectDialogOpen}
+                onClose={() => setConnectDialogOpen(false)}
+                onConnect={handleConnect}
+                containers={containers.filter(c => !networkDetails?.Containers?.[c.Id])}
+            />
+        </>
+    );
+};
+
+export default NetworkInspectDialog;

--- a/app/frontend/src/components/NetworkList.js
+++ b/app/frontend/src/components/NetworkList.js
@@ -5,6 +5,8 @@ import {
 import { Delete, Refresh } from '@mui/icons-material';
 import * as api from '../services/api';
 import ConfirmationDialog from './ConfirmationDialog';
+import CreateNetworkDialog from './CreateNetworkDialog';
+import NetworkInspectDialog from './NetworkInspectDialog';
 import { useDocker } from '../context/DockerContext';
 import { useAuth } from '../context/AuthContext';
 
@@ -12,7 +14,10 @@ const NetworkList = () => {
   const { networks, loading, refresh } = useDocker();
   const { user } = useAuth();
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [inspectDialogOpen, setInspectDialogOpen] = useState(false);
   const [selectedNetwork, setSelectedNetwork] = useState(null);
+  const [selectedNetworkId, setSelectedNetworkId] = useState(null);
   const [confirmAction, setConfirmAction] = useState(null);
 
   const handleRemoveClick = (network) => {
@@ -36,13 +41,23 @@ const NetworkList = () => {
     }
   };
 
+  const handleInspectClick = (networkId) => {
+    setSelectedNetworkId(networkId);
+    setInspectDialogOpen(true);
+  };
+
   return (
     <div>
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-xl font-semibold text-gray-800">Networks</h2>
-        <Button variant="contained" onClick={refresh} disabled={loading.networks} startIcon={<Refresh />}>
-          Refresh
-        </Button>
+        <div>
+            <Button variant="contained" onClick={() => setCreateDialogOpen(true)} sx={{ mr: 1 }}>
+                Create Network
+            </Button>
+            <Button variant="contained" onClick={refresh} disabled={loading.networks} startIcon={<Refresh />}>
+                Refresh
+            </Button>
+        </div>
       </div>
       <div className="overflow-x-auto">
         <table className="min-w-full bg-white">
@@ -62,7 +77,11 @@ const NetworkList = () => {
               </tr>
             ) : networks.map((network) => (
               <tr key={network.Id} className="hover:bg-gray-50">
-                <td className="px-6 py-4 whitespace-nowrap">{network.Name}</td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                    <span className="cursor-pointer text-blue-600 hover:underline" onClick={() => handleInspectClick(network.Id)}>
+                        {network.Name}
+                    </span>
+                </td>
                 <td className="px-6 py-4 whitespace-nowrap font-mono text-sm text-gray-500">{network.Id.substring(0, 12)}</td>
                 <td className="px-6 py-4 whitespace-nowrap">{network.Driver}</td>
                 <td className="px-6 py-4 whitespace-nowrap">{network.Scope}</td>
@@ -96,6 +115,19 @@ const NetworkList = () => {
           description={`Are you sure you want to remove this network? ${selectedNetwork.Name}`}
         />
       )}
+      <CreateNetworkDialog
+        open={createDialogOpen}
+        onClose={() => setCreateDialogOpen(false)}
+        onNetworkCreated={() => {
+            setCreateDialogOpen(false);
+            refresh();
+        }}
+      />
+        <NetworkInspectDialog
+            open={inspectDialogOpen}
+            onClose={() => setInspectDialogOpen(false)}
+            networkId={selectedNetworkId}
+        />
     </div>
   );
 };


### PR DESCRIPTION
This commit adds the frontend UI for the remaining network management features.

- A "Create Network" dialog has been added to allow you to create new Docker networks from the UI.
- The network list now has clickable network names, which open an inspection dialog showing detailed information about the network.
- The network inspection dialog now lists all containers connected to the network.
- You can now connect and disconnect containers from the network directly from the inspection dialog.