### PR TITLE
fix: Correctly expose ports when creating a new container

### DIFF
--- a/app/frontend/src/components/CreateContainerDialog.js
+++ b/app/frontend/src/components/CreateContainerDialog.js
@@ -57,9 +57,17 @@ const CreateContainerDialog = ({ open, onClose, onCreated }) => {
         return portBindings;
     };
 
+    const exposedPorts = {};
+    ports.forEach(p => {
+        if (p.container) {
+            exposedPorts[`${p.container}/tcp`] = {};
+        }
+    });
+
     const config = {
       Image: image,
       name: name,
+      ExposedPorts: exposedPorts,
       Env: envs.filter(e => e.key).map(e => `${e.key}=${e.value}`),
       HostConfig: {
         PortBindings: formatPorts(),


### PR DESCRIPTION
This commit fixes a bug where port mappings for newly created containers were not being displayed in the UI.

The issue was caused by the missing `ExposedPorts` property in the container creation request. This property is necessary to declare which ports should be exposed from the container. Without it, the `PortBindings` in the `HostConfig` were not being correctly applied by the Docker daemon.

The `CreateContainerDialog.js` component has been updated to include the `ExposedPorts` property in the configuration object sent to the backend, ensuring that port mappings are now correctly created and subsequently displayed.